### PR TITLE
Included missing `package.artifact` declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ This installs the plugin into your `node_modules` and adds the dev-dependency to
 plugins:
   - serverless-custom-packaging-plugin
 ...
+package:
+  artifact: path/to/my/artifact.zip
+...
 functions:
   myFunction:
     ...


### PR DESCRIPTION
Without specifying `package.artifact`, Serverless continues to use its own package